### PR TITLE
Add missing JSON tags to struct fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ type Line struct {
 //Paths can be open, where the first and last points in the list are considered not connected,
 //or closed, where the first and last points are considered connected.
 type Path struct {
-	Points []Point
-	Closed bool `json:"closed"`
+	Points []Point `json:"points"`
+	Closed bool    `json:"closed"`
 }
 
 //Boxes are represented by pairs of points that are opposite corners of the box.

--- a/nullBox.go
+++ b/nullBox.go
@@ -7,7 +7,7 @@ import (
 
 type NullBox struct {
 	Box
-	Valid bool
+	Valid bool `json:"valid"`
 }
 
 func (b NullBox) Value() (driver.Value, error) {

--- a/nullCircle.go
+++ b/nullCircle.go
@@ -7,7 +7,7 @@ import (
 
 type NullCircle struct {
 	Circle
-	Valid bool
+	Valid bool `json:"valid"`
 }
 
 func (c NullCircle) Value() (driver.Value, error) {

--- a/nullLine.go
+++ b/nullLine.go
@@ -7,7 +7,7 @@ import (
 
 type NullLine struct {
 	Line
-	Valid bool
+	Valid bool `json:"valid"`
 }
 
 func (l NullLine) Value() (driver.Value, error) {

--- a/nullLseg.go
+++ b/nullLseg.go
@@ -7,7 +7,7 @@ import (
 
 type NullLseg struct {
 	Lseg
-	Valid bool
+	Valid bool `json:"valid"`
 }
 
 func (l NullLseg) Value() (driver.Value, error) {

--- a/nullPath.go
+++ b/nullPath.go
@@ -7,7 +7,7 @@ import (
 
 type NullPath struct {
 	Path
-	Valid bool
+	Valid bool `json:"valid"`
 }
 
 func (p NullPath) Value() (driver.Value, error) {

--- a/nullPoint.go
+++ b/nullPoint.go
@@ -7,7 +7,7 @@ import (
 
 type NullPoint struct {
 	Point
-	Valid bool
+	Valid bool `json:"valid"`
 }
 
 func (p NullPoint) Value() (driver.Value, error) {

--- a/nullPolygon.go
+++ b/nullPolygon.go
@@ -7,7 +7,7 @@ import (
 
 type NullPolygon struct {
 	Polygon
-	Valid bool
+	Valid bool `json:"valid"`
 }
 
 func (p NullPolygon) Value() (driver.Value, error) {

--- a/path.go
+++ b/path.go
@@ -14,8 +14,8 @@ var closedPathRegexp = regexp.MustCompile(`^\(\(`)
 // Paths can be open, where the first and last points in the list are considered not connected,
 // or closed, where the first and last points are considered connected.
 type Path struct {
-	Points []Point
-	Closed bool
+	Points []Point `json:"points"`
+	Closed bool    `json:"closed"`
 }
 
 func (p Path) Value() (driver.Value, error) {


### PR DESCRIPTION
I'm opening this PR to add missing JSON tags to struct fields. This will facilitate the serialization of the structs to use in JSON API's.